### PR TITLE
feat: Move API key error to post-login notification

### DIFF
--- a/Projects/StockWatch/app.js
+++ b/Projects/StockWatch/app.js
@@ -279,6 +279,21 @@ document.addEventListener('DOMContentLoaded', () => {
             });
     });
 
+    const checkAndDisplayApiKeyError = () => {
+        const postLoginErrorContainer = document.getElementById('post-login-error-container');
+        if (!postLoginErrorContainer) return;
+
+        const hasPlaceholders = userPolygonApiKey.startsWith('YOUR_') ||
+                                userAlphaVantageApiKey.startsWith('YOUR_') ||
+                                userLogoDevApiKey.startsWith('YOUR_');
+
+        if (hasPlaceholders) {
+            postLoginErrorContainer.classList.remove('hidden');
+        } else {
+            postLoginErrorContainer.classList.add('hidden');
+        }
+    };
+
     const saveApiKeys = async (user) => {
         if (!user) return;
         const apiKeys = {
@@ -294,6 +309,7 @@ document.addEventListener('DOMContentLoaded', () => {
             userAlphaVantageApiKey = apiKeys.alphaVantage || userAlphaVantageApiKey;
             userLogoDevApiKey = apiKeys.logoDev || userLogoDevApiKey;
             apiKeyModal.classList.add('hidden');
+            checkAndDisplayApiKeyError(); // Re-run check after saving
         } catch (error) {
             console.error("Error saving API keys: ", error);
             alert("Could not save API keys. Please try again.");
@@ -340,6 +356,7 @@ document.addEventListener('DOMContentLoaded', () => {
             loginContainer.classList.add('hidden');
             appContent.classList.remove('hidden');
             await loadApiKeys(user); // Load keys on login
+            checkAndDisplayApiKeyError(); // Run check after loading keys
             initializeAccountData();
             fetchMovers();
         } else {

--- a/Projects/StockWatch/index.html
+++ b/Projects/StockWatch/index.html
@@ -104,6 +104,12 @@
                     Logout
                 </button>
             </div>
+
+            <!-- Post-Login API Key Error Message -->
+            <div id="post-login-error-container" class="hidden p-4 m-4 bg-red-100 dark:bg-red-900/30 border border-red-400 dark:border-red-600 text-red-700 dark:text-red-300 rounded-lg">
+                <p><strong class="font-bold">Configuration Needed:</strong> Your API keys are missing. Please open the menu and go to "Profile & API Keys" to add them.</p>
+            </div>
+
             <div class="px-6 py-4">
                 <p class="text-black/60 dark:text-white/60 text-base font-medium">Total Account Value</p>
                 <p id="account-value" class="text-black dark:text-white text-4xl font-bold mt-1">$12,345.67</p>


### PR DESCRIPTION
This commit refactors the API key configuration check to improve user experience.

The check for placeholder API keys is moved from a pre-login, blocking error to a non-blocking notification that appears on the main application page after the user logs in. This allows users to access the application and use the UI to enter their API keys, which then dismisses the error message.