### PR TITLE
feat: Use placeholder signing for APK build

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -33,14 +33,14 @@ jobs:
           cd Projects/SandboxAPK
           cordova platform add android@12
 
-      - name: Decode Keystore and Replace Placeholders
+      - name: Generate Keystore and Replace Placeholders
         run: |
           cd Projects/SandboxAPK
-          echo "${{ secrets.KEYSTORE_B64 }}" | base64 --decode > release.keystore
+          keytool -genkey -v -keystore release.keystore -alias placeholder-alias -keyalg RSA -keysize 2048 -validity 10000 -storepass password -keypass password -dname "CN=Placeholder, OU=, O=, L=, S=, C=US"
           sed -i 's|"keystore": "placeholder.keystore"|"keystore": "release.keystore"|' build.json
-          sed -i 's|YOUR_STORE_PASSWORD|${{ secrets.KEYSTORE_PASSWORD }}|' build.json
-          sed -i 's|YOUR_ALIAS|${{ secrets.KEY_ALIAS }}|' build.json
-          sed -i 's|YOUR_KEY_PASSWORD|${{ secrets.KEY_PASSWORD }}|' build.json
+          sed -i 's|YOUR_STORE_PASSWORD|password|' build.json
+          sed -i 's|YOUR_ALIAS|placeholder-alias|' build.json
+          sed -i 's|YOUR_KEY_PASSWORD|password|' build.json
 
       - name: Build Release APK
         run: |


### PR DESCRIPTION
Modified the GitHub Actions workflow to generate a placeholder keystore and credentials on the fly. This allows the APK to be built for testing purposes without requiring pre-configured GitHub secrets.

The workflow now:
- Generates a `release.keystore` file using `keytool`.
- Replaces placeholders in `build.json` with hardcoded credentials for the generated keystore.