### PR TITLE
fix: Update Java version to 17 for Gradle compatibility

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           node-version: '18'
 
-      - name: Set up Java (JDK 11)
+      - name: Set up Java (JDK 17)
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: Install Cordova
         run: npm install -g cordova


### PR DESCRIPTION
The build was failing because the Gradle version used by Cordova requires Java 17 or later, but the workflow was configured to use Java 11.

This commit updates the `setup-java` action to use Java 17, which resolves the build error.