### PR TITLE
Fix(android): Resolve Gradle build failure by adding groovy-xml

### DIFF
--- a/Projects/SandboxAPK/build-extras.gradle
+++ b/Projects/SandboxAPK/build-extras.gradle
@@ -1,0 +1,14 @@
+// In this file you can add your custom build logic.
+// For example, you can hook into the Android build process adding extra Gradle dependencies:
+//
+// android {
+//     dependencies {
+//         implementation 'com.google.android.gms:play-services-auth:15.0.1'
+//     }
+// }
+
+android {
+    dependencies {
+        implementation 'org.codehaus.groovy:groovy-xml:3.0.9'
+    }
+}

--- a/Projects/SandboxAPK/config.xml
+++ b/Projects/SandboxAPK/config.xml
@@ -8,4 +8,7 @@
     <content src="index.html" />
     <allow-intent href="http://*/*" />
     <allow-intent href="https://*/*" />
+    <platform name="android">
+        <resource-file src="build-extras.gradle" target="app/build-extras.gradle" />
+    </platform>
 </widget>


### PR DESCRIPTION
The Android build was failing with an `unable to resolve class XmlParser` error. This is a known issue with newer versions of Gradle where the `groovy-xml` dependency is no longer included by default.

This commit resolves the issue by:
1.  Creating a `build-extras.gradle` file to explicitly add `org.codehaus.groovy:groovy-xml:3.0.9` as a dependency.
2.  Updating `config.xml` to reference this new Gradle file, ensuring it's included in the Android build process.