### PR TITLE
Fix(android): Resolve Gradle build failure by applying groovy-xml to …

### DIFF
--- a/Projects/SandboxAPK/build-extras.gradle
+++ b/Projects/SandboxAPK/build-extras.gradle
@@ -1,13 +1,9 @@
 // In this file you can add your custom build logic.
-// For example, you can hook into the Android build process adding extra Gradle dependencies:
-//
-// android {
-//     dependencies {
-//         implementation 'com.google.android.gms:play-services-auth:15.0.1'
-//     }
-// }
-
-android {
+// The original error comes from the CordovaLib module, not just the main app.
+// By using rootProject.subprojects, we apply this dependency to all
+// sub-modules in the project, which includes both 'app' and 'CordovaLib',
+// ensuring the groovy-xml classes are available where needed.
+rootProject.subprojects {
     dependencies {
         implementation 'org.codehaus.groovy:groovy-xml:3.0.9'
     }


### PR DESCRIPTION
…all subprojects

The Android build was failing with an `unable to resolve class XmlParser` error within the `CordovaLib` module. This is a known issue with newer versions of Gradle where the `groovy-xml` dependency is no longer included by default.

This commit resolves the issue by:
1.  Creating a `build-extras.gradle` file that applies the `org.codehaus.groovy:groovy-xml:3.0.9` dependency to all subprojects, ensuring it's available to `CordovaLib`.
2.  Updating `config.xml` to reference this new Gradle file, ensuring it's included in the Android build process.